### PR TITLE
Fixing a typo in the available keys, forgetting the comma. Also, shortening the documentation requirements on valid keys

### DIFF
--- a/QualtricsAPI/Survey/responses.py
+++ b/QualtricsAPI/Survey/responses.py
@@ -220,7 +220,7 @@ class Responses(Credentials):
             'startDate',
             'endDate',
             'timeZone',
-            'breakoutSets'
+            'breakoutSets',
             'sortByLastModifiedDate',
             'filterId',
             'embeddedDataIds',
@@ -229,7 +229,7 @@ class Responses(Credentials):
         ]
 
         for key in list(kwargs.keys()):
-            assert key in valid_keys, "Hey there! You can only pass in parameters with names in the list, ['useLabels', 'includeLabelColumns', 'exportResponsesInProgress', 'limit', 'seenUnansweredRecode', 'multiselectSeenUnansweredRecode', 'includeDisplayOrder', 'startDate', 'endDate', 'timeZone']"
+            assert key in valid_keys, f"Hey there! You can only pass in parameters with names in the list, [{', ', valid_keys}]"
             if key == 'useLabels':
                 assert 'includeLabelColumns' not in list(kwargs.keys(
                 )), 'Hey there, you cannot pass both the "includeLabelColumns" and the "useLabels" parameters at the same time. Please pass just one and try again.'

--- a/QualtricsAPI/Survey/responses.py
+++ b/QualtricsAPI/Survey/responses.py
@@ -229,7 +229,7 @@ class Responses(Credentials):
         ]
 
         for key in list(kwargs.keys()):
-            assert key in valid_keys, f"Hey there! You can only pass in parameters with names in the list, [{', ', valid_keys}]"
+            assert key in valid_keys, f"Hey there! You can only pass in parameters with names in the list, [{', '.join(valid_keys)}]"
             if key == 'useLabels':
                 assert 'includeLabelColumns' not in list(kwargs.keys(
                 )), 'Hey there, you cannot pass both the "includeLabelColumns" and the "useLabels" parameters at the same time. Please pass just one and try again.'


### PR DESCRIPTION
This pull request deals with two things:
1. 'breakoutSets' within the `get_survey_responses` method didn't have a comma.  This caused it to blend with the line below, and it was being raised.
2. The documentation between the allowed arguments and the response from the raise statement was inconsistent.  Instead of typing each argument manually, I joined the available options together.  This will keep the raise consistent without the need to update in two spots.
